### PR TITLE
Enhance dashboards and add patient/pharmacy tools

### DIFF
--- a/src/app/(app)/import/page.tsx
+++ b/src/app/(app)/import/page.tsx
@@ -10,6 +10,7 @@ import Papa from "papaparse";
 import { useClaims } from "@/hooks/use-claims";
 import { useRouter } from "next/navigation";
 import type { Claim } from "@/lib/types";
+import { parseBooleanFlag, parseCurrency } from "@/lib/utils";
 
 export default function ImportPage() {
   const { toast } = useToast();
@@ -43,7 +44,7 @@ export default function ImportPage() {
       // @ts-ignore
       complete: async (results: { data: any[] }) => {
         try {
-          const newClaims: Omit<Claim, 'id'>[] = results.data.map((row: any, index: number) => {
+          const newClaims: Omit<Claim, "id">[] = results.data.map((row: any, index: number) => {
             
             const parseDate = (dateString: string) => {
               if (!dateString) return new Date().toISOString().split('T')[0];
@@ -71,16 +72,16 @@ export default function ImportPage() {
               patientId: patientId, // Assign a temporary patientId
               serviceDescription: row["Service"] || '',
               productId: row["CPT/HCPCS Code"] || '',
-              amount: parseFloat(row["Billed"] || '0'),
-              paid: parseFloat(row["Paid"] || '0'),
-              adjustment: parseFloat(row["Adjustment"] || '0'),
-              patientPay: parseFloat(row["Patient Pay"] || '0'),
+              amount: parseCurrency(row["Billed"]),
+              paid: parseCurrency(row["Paid"]),
+              adjustment: parseCurrency(row["Adjustment"]),
+              patientPay: parseCurrency(row["Patient Pay"]),
               paymentStatus: row["Payment Status"] || 'PENDING',
               postingStatus: row["Posting Status"] || 'Unposted',
               workflow: row["Workflow"] || 'New',
               notes: row["Notes"] || '',
-              statementSent: row["1st Statement Sent?"]?.toLowerCase() === 'true',
-              statementSent2nd: row["2nd Statement Sent?"]?.toLowerCase() === 'true',
+              statementSent: parseBooleanFlag(row["1st Statement Sent?"]),
+              statementSent2nd: parseBooleanFlag(row["2nd Statement Sent?"]),
             };
           });
 
@@ -96,7 +97,7 @@ export default function ImportPage() {
           
           setSelectedFile(null);
           const fileInput = document.getElementById('csv-upload') as HTMLInputElement;
-          if(fileInput) fileInput.value = '';
+          if (fileInput) fileInput.value = '';
 
           // Redirect to the dashboard to see the new data
           setTimeout(() => router.push('/dashboard'), 1500);

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,8 +4,13 @@
 import {
   FileUp,
   Home,
+  Users,
+  Building2,
+  StickyNote,
+  Cloud,
 } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import React from "react";
 
 import {
@@ -38,52 +43,112 @@ function AppAuthenticatedLayout({ children }: { children: React.ReactNode }) {
   }
 
 
+  const pathname = usePathname();
+
+  const navLinks = [
+    { href: "/dashboard", label: "Dashboard", icon: Home },
+    { href: "/patients", label: "Patients", icon: Users },
+    { href: "/pharmacies", label: "Pharmacies", icon: Building2 },
+    { href: "/import", label: "Import Data", icon: FileUp },
+    { href: "/notes", label: "Jenn's Notes", icon: StickyNote },
+    { href: "/storage", label: "File Library", icon: Cloud },
+  ];
+
   return (
-      <div className="flex min-h-screen w-full flex-col bg-muted/40">
-        <aside className="fixed inset-y-0 left-0 z-10 hidden w-14 flex-col border-r bg-background sm:flex">
-          <nav className="flex flex-col items-center gap-4 px-2 sm:py-5">
+      <div className="flex min-h-screen w-full flex-col bg-transparent">
+        <aside className="fixed inset-y-0 left-0 z-20 hidden w-20 flex-col border-r border-white/30 bg-white/40 pb-6 pt-8 shadow-2xl shadow-indigo-200/40 backdrop-blur-2xl sm:flex">
+          <nav className="flex flex-1 flex-col items-center gap-6 px-3">
             <Link
               href="/dashboard"
-              className="group flex h-9 w-9 shrink-0 items-center justify-center gap-2 rounded-full bg-primary text-lg font-semibold text-primary-foreground md:h-8 md:w-8 md:text-base"
+              className="group flex h-12 w-12 items-center justify-center rounded-3xl bg-gradient-to-br from-indigo-500 to-sky-500 text-white shadow-xl shadow-sky-400/40 transition hover:scale-105"
             >
-              <Logo className="h-4 w-4 transition-all group-hover:scale-110" />
+              <Logo className="h-5 w-5 transition-transform group-hover:rotate-6" />
               <span className="sr-only">Jenn's Billing</span>
             </Link>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    href="/dashboard"
-                    className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8"
-                  >
-                    <Home className="h-5 w-5" />
-                    <span className="sr-only">Dashboard</span>
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent side="right">Dashboard</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    href="/import"
-                    className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8"
-                  >
-                    <FileUp className="h-5 w-5" />
-                    <span className="sr-only">Import Data</span>
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent side="right">Import Data</TooltipContent>
-              </Tooltip>
+            <TooltipProvider delayDuration={80}>
+              {navLinks.map((item) => {
+                const isActive = pathname.startsWith(item.href);
+                return (
+                  <Tooltip key={item.href}>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={item.href}
+                        className={`flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 text-slate-600 shadow transition ${
+                          isActive
+                            ? "bg-gradient-to-br from-indigo-400 to-sky-400 text-white"
+                            : "bg-white/40 hover:bg-white/70 hover:text-slate-900"
+                        }`}
+                      >
+                        <item.icon className="h-5 w-5" />
+                        <span className="sr-only">{item.label}</span>
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="rounded-xl border border-white/40 bg-white/80 text-slate-600 shadow">
+                      {item.label}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
             </TooltipProvider>
           </nav>
         </aside>
-        <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-14">
-          <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
-            {children}
+        <div className="flex flex-col sm:pl-20">
+          <header className="sticky top-0 z-10 border-b border-white/40 bg-white/60 px-4 py-4 shadow-sm shadow-sky-100/60 backdrop-blur">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-400 to-sky-500 text-white shadow-lg">
+                  <Logo className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Jenn's Dream Billing</p>
+                  <p className="text-lg font-semibold text-slate-700">Carefully curated statements</p>
+                </div>
+              </div>
+              <nav className="hidden gap-2 md:flex">
+                {navLinks.map((item) => {
+                  const isActive = pathname.startsWith(item.href);
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={`rounded-full border border-white/50 px-4 py-2 text-sm font-medium shadow-sm transition ${
+                        isActive
+                          ? "bg-gradient-to-r from-indigo-400 to-sky-500 text-white"
+                          : "bg-white/60 text-slate-600 hover:bg-white hover:text-slate-900"
+                      }`}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </div>
+          </header>
+          <main className="flex-1 p-4 sm:p-8">
+            <div className="glass-panel glow-ring min-h-[calc(100vh-7rem)] w-full p-6 sm:p-8">
+              {children}
+            </div>
           </main>
         </div>
+        <nav className="fixed inset-x-4 bottom-4 z-30 flex items-center justify-between rounded-3xl border border-white/40 bg-white/70 px-4 py-3 shadow-2xl shadow-sky-200/50 backdrop-blur md:hidden">
+          {navLinks.map((item) => {
+            const isActive = pathname.startsWith(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex flex-col items-center gap-1 text-xs font-medium transition ${
+                  isActive ? "text-sky-600" : "text-slate-500 hover:text-slate-700"
+                }`}
+              >
+                <item.icon className="h-5 w-5" />
+                {item.label.split(" ")[0]}
+              </Link>
+            );
+          })}
+        </nav>
       </div>
-  )
+  );
 }
 
 

--- a/src/app/(app)/notes/page.tsx
+++ b/src/app/(app)/notes/page.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import * as React from "react";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useJennNotes } from "@/hooks/use-notes";
+import type { JennNote } from "@/lib/types";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import { Plus, Pencil, Trash2, Sparkles, Clock } from "lucide-react";
+
+const moodMeta: Record<NonNullable<JennNote["mood"]>, { label: string; gradient: string; accent: string }> = {
+  celebrate: {
+    label: "Celebrate",
+    gradient: "from-emerald-400/70 via-teal-300/80 to-sky-300/80",
+    accent: "bg-emerald-400/80",
+  },
+  todo: {
+    label: "To-Do",
+    gradient: "from-indigo-400/70 via-sky-400/80 to-cyan-300/70",
+    accent: "bg-indigo-400/80",
+  },
+  "follow-up": {
+    label: "Follow Up",
+    gradient: "from-amber-300/80 via-orange-300/80 to-pink-300/70",
+    accent: "bg-amber-400/80",
+  },
+  idea: {
+    label: "Idea",
+    gradient: "from-violet-400/70 via-purple-400/70 to-sky-400/70",
+    accent: "bg-violet-400/80",
+  },
+};
+
+const moodFilterOptions: Array<{ value: "all" | NonNullable<JennNote["mood"]>; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "celebrate", label: "Celebrate" },
+  { value: "todo", label: "To-Do" },
+  { value: "follow-up", label: "Follow Up" },
+  { value: "idea", label: "Ideas" },
+];
+
+function formatRelative(date: string) {
+  const dt = new Date(date);
+  if (Number.isNaN(dt.getTime())) return date;
+  return dt.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+type NoteDraft = {
+  title: string;
+  body: string;
+  tags: string;
+  mood: NonNullable<JennNote["mood"]>;
+};
+
+const emptyDraft: NoteDraft = {
+  title: "",
+  body: "",
+  tags: "",
+  mood: "todo",
+};
+
+export default function NotesPage() {
+  const { notes, isLoading, addNote, updateNote, removeNote } = useJennNotes();
+  const { toast } = useToast();
+
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [moodFilter, setMoodFilter] = React.useState<(typeof moodFilterOptions)[number]["value"]>("all");
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [createDraft, setCreateDraft] = React.useState<NoteDraft>(emptyDraft);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [editingNote, setEditingNote] = React.useState<JennNote | null>(null);
+  const [editingDraft, setEditingDraft] = React.useState<NoteDraft>(emptyDraft);
+
+  const filteredNotes = React.useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    return notes
+      .filter((note) =>
+        moodFilter === "all" ? true : note.mood === moodFilter
+      )
+      .filter((note) => {
+        if (!normalizedSearch) return true;
+        const haystack = [note.title, note.body, ...(note.tags ?? [])]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(normalizedSearch);
+      });
+  }, [notes, searchTerm, moodFilter]);
+
+  const tagCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    notes.forEach((note) => {
+      (note.tags ?? []).forEach((tag) => {
+        const trimmed = tag.trim();
+        if (!trimmed) return;
+        counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+      });
+    });
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  }, [notes]);
+
+  const handleCreateNote = async () => {
+    if (!createDraft.title || !createDraft.body) {
+      toast({
+        title: "Add a title and note",
+        description: "Both fields are needed to create a note.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await addNote({
+        title: createDraft.title,
+        body: createDraft.body,
+        tags: createDraft.tags
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+        mood: createDraft.mood,
+      });
+      setCreateDraft(emptyDraft);
+      setCreateOpen(false);
+      toast({
+        title: "Note saved",
+        description: "Your thoughts were captured for Jenn!",
+      });
+    } catch (error) {
+      console.error("Failed to add note", error);
+      toast({
+        title: "Unable to add note",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const openEdit = (note: JennNote) => {
+    setEditingNote(note);
+    setEditingDraft({
+      title: note.title,
+      body: note.body,
+      tags: (note.tags ?? []).join(", "),
+      mood: note.mood ?? "todo",
+    });
+  };
+
+  const handleUpdateNote = async () => {
+    if (!editingNote) return;
+    if (!editingDraft.title || !editingDraft.body) {
+      toast({
+        title: "Add a title and note",
+        description: "Both fields are needed to update a note.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await updateNote(editingNote.id, {
+        title: editingDraft.title,
+        body: editingDraft.body,
+        tags: editingDraft.tags
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+        mood: editingDraft.mood,
+      });
+      setEditingNote(null);
+      toast({
+        title: "Note updated",
+        description: "Changes have been saved.",
+      });
+    } catch (error) {
+      console.error("Failed to update note", error);
+      toast({
+        title: "Unable to update note",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteNote = async (note: JennNote) => {
+    try {
+      await removeNote(note.id);
+      toast({
+        title: "Note removed",
+        description: "That entry is now archived.",
+      });
+    } catch (error) {
+      console.error("Failed to delete note", error);
+      toast({
+        title: "Unable to delete note",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const summary = React.useMemo(() => {
+    return {
+      total: notes.length,
+      celebrate: notes.filter((note) => note.mood === "celebrate").length,
+      actionable: notes.filter((note) => note.mood === "todo" || note.mood === "follow-up").length,
+    };
+  }, [notes]);
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Jenn's Notes"
+        description="Capture wins, reminders, and ideas in one vibrant workspace."
+        children={
+          <Button
+            onClick={() => setCreateOpen(true)}
+            className="rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-teal-400 px-5 text-white shadow-lg hover:shadow-xl"
+          >
+            <Plus className="mr-2 h-4 w-4" /> New note
+          </Button>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+        <div className="space-y-4">
+          <Card className="border-none bg-white/70 p-[1px] shadow-xl shadow-sky-200/50">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="space-y-3 border-b border-white/60">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-700">
+                  <Sparkles className="h-5 w-5 text-sky-500" /> Filters
+                </CardTitle>
+                <div className="space-y-3">
+                  <Input
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Search notes"
+                    className="h-11 rounded-2xl border-none bg-white/80 px-4 text-sm shadow-inner"
+                  />
+                  <Tabs
+                    value={moodFilter}
+                    onValueChange={(value) => setMoodFilter(value as (typeof moodFilterOptions)[number]["value"])}
+                  >
+                    <TabsList className="grid h-11 grid-cols-5 rounded-2xl bg-slate-100/60 p-[2px]">
+                      {moodFilterOptions.map((option) => (
+                        <TabsTrigger
+                          key={option.value}
+                          value={option.value}
+                          className="rounded-2xl px-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500 transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-indigo-400 data-[state=active]:to-sky-400 data-[state=active]:text-white"
+                        >
+                          {option.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4 p-6">
+                <div className="grid gap-3">
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total Notes</p>
+                    <p className="mt-1 text-2xl font-semibold text-slate-700">{summary.total}</p>
+                    <p className="text-xs text-slate-500">Jenn's journal of billing brilliance</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Actionable</p>
+                    <p className="mt-1 text-2xl font-semibold text-slate-700">{summary.actionable}</p>
+                    <p className="text-xs text-slate-500">Follow-ups & to-dos</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Celebrations</p>
+                    <p className="mt-1 text-2xl font-semibold text-slate-700">{summary.celebrate}</p>
+                    <p className="text-xs text-slate-500">Wins worth sharing</p>
+                  </div>
+                </div>
+
+                {tagCounts.length > 0 && (
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Top tags</p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {tagCounts.slice(0, 8).map(([tag, count]) => (
+                        <Badge key={tag} variant="outline" className="rounded-full border-slate-200 text-slate-600">
+                          #{tag} · {count}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </div>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          {isLoading ? (
+            <div className="rounded-3xl border border-dashed border-slate-200/80 bg-white/70 p-12 text-center text-sm text-slate-500">
+              Loading Jenn's notes...
+            </div>
+          ) : filteredNotes.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-slate-200/80 bg-white/70 p-12 text-center text-sm text-slate-500">
+              No notes match your filters yet.
+            </div>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {filteredNotes.map((note) => {
+                const mood = note.mood ?? "todo";
+                const meta = moodMeta[mood];
+                return (
+                  <Card key={note.id} className="border-none bg-transparent p-[1px]">
+                    <div
+                      className={cn(
+                        "flex h-full flex-col rounded-3xl border border-white/50 bg-white/80 p-6 shadow-xl transition hover:-translate-y-1 hover:shadow-2xl",
+                        `bg-gradient-to-br ${meta.gradient}`
+                      )}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <Badge className={cn("rounded-full px-3 py-1 text-xs font-semibold text-white", meta.accent)}>
+                          {meta.label}
+                        </Badge>
+                        <span className="flex items-center gap-1 text-xs text-white/80">
+                          <Clock className="h-3.5 w-3.5" /> {formatRelative(note.updatedAt)}
+                        </span>
+                      </div>
+                      <h3 className="mt-4 text-xl font-semibold text-white">{note.title}</h3>
+                      <p className="mt-3 flex-1 whitespace-pre-line text-sm text-white/90">{note.body}</p>
+                      {note.tags && note.tags.length > 0 && (
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          {note.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded-full bg-white/30 px-3 py-1 text-xs font-medium text-white/90 backdrop-blur"
+                            >
+                              #{tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                      <div className="mt-6 flex items-center justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-full bg-white/30 text-white hover:bg-white/50"
+                          onClick={() => openEdit(note)}
+                        >
+                          <Pencil className="mr-1.5 h-4 w-4" /> Edit
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-full bg-white/20 text-white hover:bg-white/40"
+                          onClick={() => handleDeleteNote(note)}
+                        >
+                          <Trash2 className="mr-1.5 h-4 w-4" /> Delete
+                        </Button>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog open={createOpen} onOpenChange={(open) => {
+        setCreateOpen(open);
+        if (!open) {
+          setCreateDraft(emptyDraft);
+        }
+      }}>
+        <DialogContent className="max-w-lg rounded-3xl border border-white/60 bg-white/90 shadow-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold text-slate-700">New note</DialogTitle>
+            <DialogDescription className="text-sm text-slate-500">
+              Capture a quick update, reminder, or celebration for Jenn.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <Input
+              value={createDraft.title}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, title: event.target.value }))}
+              placeholder="Title"
+              className="h-11 rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Textarea
+              value={createDraft.body}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, body: event.target.value }))}
+              placeholder="Write your note"
+              className="min-h-[140px] rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Input
+              value={createDraft.tags}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, tags: event.target.value }))}
+              placeholder="Tags (comma separated)"
+              className="h-11 rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Tabs
+              value={createDraft.mood}
+              onValueChange={(value) => setCreateDraft((draft) => ({ ...draft, mood: value as NoteDraft["mood"] }))}
+            >
+              <TabsList className="grid h-11 grid-cols-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                {Object.entries(moodMeta).map(([key, meta]) => (
+                  <TabsTrigger
+                    key={key}
+                    value={key}
+                    className="rounded-2xl px-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500 transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-indigo-400 data-[state=active]:to-sky-400 data-[state=active]:text-white"
+                  >
+                    {meta.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button
+              variant="ghost"
+              className="rounded-full px-4 text-slate-500 hover:text-slate-700"
+              onClick={() => setCreateOpen(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-teal-400 px-5 text-white shadow-lg hover:shadow-xl"
+              onClick={handleCreateNote}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Saving..." : "Save note"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(editingNote)} onOpenChange={(open) => {
+        if (!open) {
+          setEditingNote(null);
+          setEditingDraft(emptyDraft);
+        }
+      }}>
+        <DialogContent className="max-w-lg rounded-3xl border border-white/60 bg-white/90 shadow-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold text-slate-700">Edit note</DialogTitle>
+            <DialogDescription className="text-sm text-slate-500">
+              Update the details for this note.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <Input
+              value={editingDraft.title}
+              onChange={(event) => setEditingDraft((draft) => ({ ...draft, title: event.target.value }))}
+              placeholder="Title"
+              className="h-11 rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Textarea
+              value={editingDraft.body}
+              onChange={(event) => setEditingDraft((draft) => ({ ...draft, body: event.target.value }))}
+              placeholder="Write your note"
+              className="min-h-[140px] rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Input
+              value={editingDraft.tags}
+              onChange={(event) => setEditingDraft((draft) => ({ ...draft, tags: event.target.value }))}
+              placeholder="Tags (comma separated)"
+              className="h-11 rounded-2xl border border-slate-200 bg-white/90"
+            />
+            <Tabs
+              value={editingDraft.mood}
+              onValueChange={(value) => setEditingDraft((draft) => ({ ...draft, mood: value as NoteDraft["mood"] }))}
+            >
+              <TabsList className="grid h-11 grid-cols-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                {Object.entries(moodMeta).map(([key, meta]) => (
+                  <TabsTrigger
+                    key={key}
+                    value={key}
+                    className="rounded-2xl px-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500 transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-indigo-400 data-[state=active]:to-sky-400 data-[state=active]:text-white"
+                  >
+                    {meta.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button
+              variant="ghost"
+              className="rounded-full px-4 text-slate-500 hover:text-slate-700"
+              onClick={() => setEditingNote(null)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-teal-400 px-5 text-white shadow-lg hover:shadow-xl"
+              onClick={handleUpdateNote}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Saving..." : "Update note"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -1,0 +1,545 @@
+"use client";
+
+import * as React from "react";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Separator } from "@/components/ui/separator";
+import { Progress } from "@/components/ui/progress";
+import { usePatients } from "@/hooks/use-patients";
+import { useClaims } from "@/hooks/use-claims";
+import type { Claim, Patient } from "@/lib/types";
+import { formatCurrency } from "@/lib/utils";
+import { Search, Activity, ClipboardList } from "lucide-react";
+
+function formatDisplayDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function getPatientName(patient: Patient) {
+  return `${patient.firstName} ${patient.lastName}`.trim();
+}
+
+type PatientSummary = {
+  claims: Claim[];
+  outstanding: number;
+  needed: number;
+  sent: number;
+  total: number;
+  totalPaid: number;
+  lastServiceDate: string | null;
+  lastUpdate: string | null;
+};
+
+const filterOptions = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "needs-action", label: "Needs Action" },
+  { value: "collections", label: "Collections" },
+];
+
+export default function PatientsPage() {
+  const { patients, isLoading: patientsLoading } = usePatients();
+  const { claims, isLoading: claimsLoading } = useClaims();
+
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [statusFilter, setStatusFilter] = React.useState<(typeof filterOptions)[number]["value"]>("all");
+  const [selectedPatientId, setSelectedPatientId] = React.useState<string | null>(null);
+  const [activeTab, setActiveTab] = React.useState("overview");
+
+  const summaries = React.useMemo(() => {
+    const map = new Map<string, PatientSummary>();
+    (claims ?? []).forEach((claim) => {
+      if (!claim.patientId) return;
+      const current = map.get(claim.patientId) ?? {
+        claims: [],
+        outstanding: 0,
+        needed: 0,
+        sent: 0,
+        total: 0,
+        totalPaid: 0,
+        lastServiceDate: null as string | null,
+        lastUpdate: null as string | null,
+      };
+
+      current.claims.push(claim);
+      current.total += 1;
+      current.totalPaid += claim.paid ?? 0;
+      const patientPayValue = claim.patientPay ?? 0;
+      if (!claim.statementSent) {
+        current.outstanding += patientPayValue;
+        current.needed += 1;
+      } else {
+        current.sent += 1;
+      }
+
+      if (claim.serviceDate) {
+        const date = new Date(claim.serviceDate).toISOString();
+        if (!current.lastServiceDate || date > current.lastServiceDate) {
+          current.lastServiceDate = date;
+        }
+      }
+
+      const possibleUpdate = claim.statementSent2ndAt ?? claim.statementSentAt ?? claim.checkDate;
+      if (possibleUpdate) {
+        const normalized = new Date(possibleUpdate).toISOString();
+        if (!current.lastUpdate || normalized > current.lastUpdate) {
+          current.lastUpdate = normalized;
+        }
+      }
+
+      map.set(claim.patientId, current);
+    });
+    return map;
+  }, [claims]);
+
+  const filteredPatients = React.useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return (patients ?? []).filter((patient) => {
+      const summary = summaries.get(patient.id);
+
+      if (statusFilter === "active" && patient.status && patient.status !== "Active") {
+        return false;
+      }
+      if (statusFilter === "needs-action" && (!summary || summary.outstanding <= 0)) {
+        return false;
+      }
+      if (statusFilter === "collections" && patient.status !== "Collections") {
+        return false;
+      }
+
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      const haystack = [
+        patient.firstName,
+        patient.lastName,
+        patient.address?.city,
+        patient.address?.state,
+        patient.address?.street,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedSearch);
+    });
+  }, [patients, searchTerm, statusFilter, summaries]);
+
+  React.useEffect(() => {
+    if (!selectedPatientId && filteredPatients.length) {
+      setSelectedPatientId(filteredPatients[0].id);
+    }
+  }, [filteredPatients, selectedPatientId]);
+
+  React.useEffect(() => {
+    if (selectedPatientId && !filteredPatients.some((patient) => patient.id === selectedPatientId)) {
+      setSelectedPatientId(filteredPatients[0]?.id ?? null);
+    }
+  }, [filteredPatients, selectedPatientId]);
+
+  const selectedPatient = React.useMemo(
+    () => filteredPatients.find((patient) => patient.id === selectedPatientId) ?? filteredPatients[0] ?? null,
+    [filteredPatients, selectedPatientId]
+  );
+
+  const selectedSummary = selectedPatient ? summaries.get(selectedPatient.id) ?? {
+    claims: [],
+    outstanding: 0,
+    needed: 0,
+    sent: 0,
+    total: 0,
+    totalPaid: 0,
+    lastServiceDate: null,
+    lastUpdate: null,
+  } : null;
+
+  const dashboardTotals = React.useMemo(() => {
+    const base = { patients: filteredPatients.length, outstanding: 0, statements: 0, collected: 0 };
+    filteredPatients.forEach((patient) => {
+      const summary = summaries.get(patient.id);
+      if (!summary) return;
+      base.outstanding += summary.outstanding;
+      base.statements += summary.needed;
+      base.collected += summary.totalPaid;
+    });
+    return base;
+  }, [filteredPatients, summaries]);
+
+  const isLoading = patientsLoading || claimsLoading;
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Patient Navigator"
+        description="Search, filter, and drill into individual patients to understand balances, activity, and statement history."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[340px,1fr]">
+        <div className="space-y-4">
+          <Card className="border-none bg-white/70 p-[1px] shadow-xl shadow-sky-200/50">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="space-y-3 border-b border-white/60">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-700">
+                  <Search className="h-5 w-5 text-sky-500" /> Patient List
+                </CardTitle>
+                <div className="flex flex-col gap-3">
+                  <Input
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Search by name, city, or ID"
+                    className="h-11 rounded-2xl border-none bg-white/80 px-4 text-sm shadow-inner"
+                  />
+                  <Tabs
+                    value={statusFilter}
+                    onValueChange={(value) => setStatusFilter(value as (typeof filterOptions)[number]["value"])}
+                  >
+                    <TabsList className="grid h-11 grid-cols-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                      {filterOptions.map((option) => (
+                        <TabsTrigger
+                          key={option.value}
+                          value={option.value}
+                          className="rounded-2xl px-2 text-xs font-semibold uppercase tracking-wide text-slate-500 transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-indigo-400 data-[state=active]:to-sky-400 data-[state=active]:text-white"
+                        >
+                          {option.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </CardHeader>
+              <CardContent className="px-0 py-0">
+                <ScrollArea className="h-[520px] px-4">
+                  <div className="space-y-3 py-4">
+                    {isLoading && (
+                      <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                        Loading patients...
+                      </div>
+                    )}
+                    {!isLoading && filteredPatients.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                        No patients match your filters right now.
+                      </div>
+                    )}
+                    {!isLoading &&
+                      filteredPatients.map((patient) => {
+                        const summary = summaries.get(patient.id);
+                        const isActive = selectedPatient && patient.id === selectedPatient.id;
+                        const outstanding = summary?.outstanding ?? 0;
+                        const lastVisit = summary?.lastServiceDate ?? patient.lastVisitAt;
+
+                        return (
+                          <button
+                            key={patient.id}
+                            onClick={() => {
+                              setSelectedPatientId(patient.id);
+                              setActiveTab("overview");
+                            }}
+                            className={`w-full rounded-3xl border p-4 text-left transition hover:shadow-lg ${
+                              isActive
+                                ? "border-transparent bg-gradient-to-r from-indigo-400/90 via-sky-400/90 to-teal-400/90 text-white shadow-xl"
+                                : "border-white/60 bg-white/70 text-slate-600 hover:bg-white"
+                            }`}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className={`text-base font-semibold ${isActive ? "text-white" : "text-slate-700"}`}>
+                                  {getPatientName(patient)}
+                                </p>
+                                <p className={`text-xs ${isActive ? "text-white/80" : "text-slate-500"}`}>
+                                  {patient.address?.city}, {patient.address?.state}
+                                </p>
+                              </div>
+                              <div className="text-right">
+                                <p className={`text-sm font-semibold ${isActive ? "text-white" : "text-slate-700"}`}>
+                                  {formatCurrency(outstanding)}
+                                </p>
+                                <p className={`text-[11px] uppercase tracking-wide ${isActive ? "text-white/80" : "text-slate-400"}`}>
+                                  Outstanding
+                                </p>
+                              </div>
+                            </div>
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                              {patient.status && (
+                                <Badge variant={isActive ? "secondary" : "outline"}>{patient.status}</Badge>
+                              )}
+                              {summary && summary.needed > 0 && (
+                                <Badge variant="destructive">{summary.needed} statements due</Badge>
+                              )}
+                              {lastVisit && (
+                                <Badge variant="outline" className={isActive ? "border-white/50 text-white" : "text-slate-500"}>
+                                  Last DOS {formatDisplayDate(lastVisit)}
+                                </Badge>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
+                  </div>
+                </ScrollArea>
+              </CardContent>
+            </div>
+          </Card>
+
+          <Card className="border-none bg-white/70 p-[1px] shadow-xl shadow-sky-200/50">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="border-b border-white/60 pb-4">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-700">
+                  <Activity className="h-5 w-5 text-teal-500" /> Patient Metrics
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 p-6">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Patients</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{dashboardTotals.patients}</p>
+                    <p className="text-xs text-slate-500">Currently visible</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Outstanding</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{formatCurrency(dashboardTotals.outstanding)}</p>
+                    <p className="text-xs text-slate-500">Across filtered patients</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Statements Due</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{dashboardTotals.statements}</p>
+                    <p className="text-xs text-slate-500">Waiting to be sent</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Insurance Paid</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{formatCurrency(dashboardTotals.collected)}</p>
+                    <p className="text-xs text-slate-500">Recorded payments</p>
+                  </div>
+                </div>
+              </CardContent>
+            </div>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card className="border-none bg-white/70 p-[1px] shadow-2xl shadow-sky-200/60">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="border-b border-white/60 pb-4">
+                <CardTitle className="flex items-center justify-between text-lg font-semibold text-slate-700">
+                  <span>Patient Overview</span>
+                  {selectedPatient && (
+                    <Badge variant="outline" className="rounded-full border-sky-200 text-sky-600">
+                      {selectedPatient.status ?? "Status Pending"}
+                    </Badge>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6 p-6">
+                {!selectedPatient && (
+                  <div className="rounded-3xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                    Select a patient from the list to view their full history.
+                  </div>
+                )}
+
+                {selectedPatient && selectedSummary && (
+                  <div className="space-y-6">
+                    <div className="grid gap-6 lg:grid-cols-2">
+                      <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Contact</h3>
+                        <p className="mt-2 text-lg font-semibold text-slate-700">{getPatientName(selectedPatient)}</p>
+                        <p className="text-sm text-slate-500">
+                          {selectedPatient.address?.street}
+                          <br />
+                          {selectedPatient.address?.city}, {selectedPatient.address?.state} {selectedPatient.address?.zip}
+                        </p>
+                        <div className="mt-3 space-y-1 text-sm text-slate-500">
+                          {selectedPatient.phone && <p>{selectedPatient.phone}</p>}
+                          {selectedPatient.email && <p>{selectedPatient.email}</p>}
+                          <p>DOB: {formatDisplayDate(selectedPatient.dateOfBirth)}</p>
+                        </div>
+                      </div>
+                      <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Statement Health</h3>
+                        <div className="mt-4 space-y-4">
+                          <div>
+                            <div className="flex items-center justify-between text-sm">
+                              <span className="text-slate-500">Progress</span>
+                              <span className="font-semibold text-slate-700">
+                                {selectedSummary.sent}/{selectedSummary.total}
+                              </span>
+                            </div>
+                            <Progress value={selectedSummary.total ? (selectedSummary.sent / selectedSummary.total) * 100 : 0} className="mt-2 h-2 rounded-full bg-slate-200/70" />
+                          </div>
+                          <div className="grid grid-cols-2 gap-3 text-sm">
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 text-center">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Outstanding</p>
+                              <p className="mt-1 text-base font-semibold text-slate-700">{formatCurrency(selectedSummary.outstanding)}</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 text-center">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Insurance Paid</p>
+                              <p className="mt-1 text-base font-semibold text-slate-700">{formatCurrency(selectedSummary.totalPaid)}</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 text-center">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Statements Needed</p>
+                              <p className="mt-1 text-base font-semibold text-slate-700">{selectedSummary.needed}</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 text-center">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Last DOS</p>
+                              <p className="mt-1 text-base font-semibold text-slate-700">{formatDisplayDate(selectedSummary.lastServiceDate)}</p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Tabs value={activeTab} onValueChange={setActiveTab}>
+                      <TabsList className="mb-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                        <TabsTrigger
+                          value="overview"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-indigo-400 data-[state=active]:to-sky-400 data-[state=active]:text-white"
+                        >
+                          Dashboard
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="history"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-400 data-[state=active]:to-teal-400 data-[state=active]:text-white"
+                        >
+                          Claim History
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="timeline"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-teal-400 data-[state=active]:to-cyan-400 data-[state=active]:text-white"
+                        >
+                          Timeline
+                        </TabsTrigger>
+                      </TabsList>
+
+                      <TabsContent value="overview" className="space-y-4">
+                        <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                          <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                            <ClipboardList className="h-4 w-4 text-sky-500" /> Summary
+                          </h3>
+                          <Separator className="my-4 bg-slate-200/70" />
+                          <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Total Claims</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{selectedSummary.total}</p>
+                              <p className="text-xs text-slate-500">Lifetime in system</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Last Update</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{formatDisplayDate(selectedSummary.lastUpdate)}</p>
+                              <p className="text-xs text-slate-500">Most recent activity</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Sent Statements</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{selectedSummary.sent}</p>
+                              <p className="text-xs text-slate-500">Marked as delivered</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Pending Statements</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{selectedSummary.needed}</p>
+                              <p className="text-xs text-slate-500">Ready for generation</p>
+                            </div>
+                          </div>
+                        </div>
+                      </TabsContent>
+
+                      <TabsContent value="history" className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        {selectedSummary.claims.length === 0 ? (
+                          <p className="text-sm text-slate-500">No claims recorded for this patient yet.</p>
+                        ) : (
+                          <div className="overflow-x-auto">
+                            <Table>
+                              <TableHeader>
+                                <TableRow className="bg-white/70">
+                                  <TableHead>DOS</TableHead>
+                                  <TableHead>Service</TableHead>
+                                  <TableHead className="text-right">Billed</TableHead>
+                                  <TableHead className="text-right">Paid</TableHead>
+                                  <TableHead className="text-right">Patient Pay</TableHead>
+                                  <TableHead>Status</TableHead>
+                                  <TableHead>Workflow</TableHead>
+                                </TableRow>
+                              </TableHeader>
+                              <TableBody>
+                                {[...selectedSummary.claims]
+                                  .sort((a, b) => (b.serviceDate ?? "").localeCompare(a.serviceDate ?? ""))
+                                  .map((claim) => (
+                                    <TableRow key={claim.id} className="transition hover:bg-sky-50/70">
+                                      <TableCell>{formatDisplayDate(claim.serviceDate)}</TableCell>
+                                      <TableCell>
+                                        <p className="font-medium text-slate-700">{claim.serviceDescription || "Service"}</p>
+                                        <p className="text-xs text-slate-500">Rx {claim.rx}</p>
+                                      </TableCell>
+                                      <TableCell className="text-right">{formatCurrency(claim.amount)}</TableCell>
+                                      <TableCell className="text-right">{formatCurrency(claim.paid)}</TableCell>
+                                      <TableCell className="text-right">{formatCurrency(claim.patientPay)}</TableCell>
+                                      <TableCell>
+                                        <Badge variant={claim.statementSent ? "outline" : "destructive"}>
+                                          {claim.statementSent ? "Sent" : "Pending"}
+                                        </Badge>
+                                      </TableCell>
+                                      <TableCell>
+                                        <Badge variant="secondary">{claim.workflow}</Badge>
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                              </TableBody>
+                            </Table>
+                          </div>
+                        )}
+                      </TabsContent>
+
+                      <TabsContent value="timeline" className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <div className="space-y-4">
+                          {selectedSummary.claims.length === 0 ? (
+                            <p className="text-sm text-slate-500">No events recorded yet.</p>
+                          ) : (
+                            [...selectedSummary.claims]
+                              .sort((a, b) => (a.serviceDate ?? "").localeCompare(b.serviceDate ?? ""))
+                              .map((claim) => (
+                                <div key={claim.id} className="flex gap-4">
+                                  <div className="relative flex flex-col items-center">
+                                    <div className="mt-1 h-4 w-4 rounded-full bg-gradient-to-br from-sky-400 to-teal-400 shadow-lg" />
+                                    <div className="mt-1 h-full w-[2px] bg-slate-200" />
+                                  </div>
+                                  <div className="flex-1 rounded-2xl border border-white/60 bg-white/70 p-4 shadow-sm">
+                                    <div className="flex flex-wrap items-center justify-between gap-2">
+                                      <div>
+                                        <p className="text-sm font-semibold text-slate-700">{formatDisplayDate(claim.serviceDate)}</p>
+                                        <p className="text-xs uppercase tracking-wide text-slate-400">Service Date</p>
+                                      </div>
+                                      <Badge variant={claim.statementSent ? "outline" : "secondary"}>
+                                        {claim.statementSent ? "Statement Sent" : "Needs Statement"}
+                                      </Badge>
+                                    </div>
+                                    <p className="mt-3 text-sm text-slate-600">
+                                      {claim.serviceDescription || "Service"} · {claim.productId || claim.rx}
+                                    </p>
+                                    <div className="mt-3 grid gap-2 text-xs text-slate-500 sm:grid-cols-3">
+                                      <p>Billed: {formatCurrency(claim.amount)}</p>
+                                      <p>Paid: {formatCurrency(claim.paid)}</p>
+                                      <p>Patient: {formatCurrency(claim.patientPay)}</p>
+                                    </div>
+                                  </div>
+                                </div>
+                              ))
+                          )}
+                        </div>
+                      </TabsContent>
+                    </Tabs>
+                  </div>
+                )}
+              </CardContent>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/pharmacies/page.tsx
+++ b/src/app/(app)/pharmacies/page.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import * as React from "react";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { usePharmacies } from "@/hooks/use-pharmacies";
+import { useClaims } from "@/hooks/use-claims";
+import type { Claim, Pharmacy } from "@/lib/types";
+import { formatCurrency } from "@/lib/utils";
+import { Building2, Filter, Layers, Target, TrendingUp } from "lucide-react";
+
+const filterOptions = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "needs-review", label: "Needs Review" },
+  { value: "prospect", label: "Prospects" },
+];
+
+function normalize(value?: string | null) {
+  return value?.toLowerCase().replace(/[^a-z0-9]/g, "") ?? "";
+}
+
+function matchesPharmacy(claim: Claim, pharmacy: Pharmacy) {
+  if (!pharmacy) return false;
+  if (pharmacy.npi && claim.npi && normalize(pharmacy.npi) === normalize(claim.npi)) {
+    return true;
+  }
+
+  const payee = normalize(claim.payee);
+  const payer = normalize(claim.payer);
+  const name = normalize(pharmacy.name);
+  const id = normalize(pharmacy.id);
+
+  if (name && payee && (payee.includes(name) || name.includes(payee))) {
+    return true;
+  }
+  if (id && payee && (payee.includes(id) || id.includes(payee))) {
+    return true;
+  }
+  if (name && payer && payer.includes(name)) {
+    return true;
+  }
+  return false;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+type PharmacySummary = {
+  claims: Claim[];
+  outstanding: number;
+  totalClaims: number;
+  totalPaid: number;
+  statementsDue: number;
+  lastCheckDate: string | null;
+  topServices: Record<string, number>;
+};
+
+export default function PharmaciesPage() {
+  const { pharmacies, isLoading: pharmaciesLoading } = usePharmacies();
+  const { claims, isLoading: claimsLoading } = useClaims();
+
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [statusFilter, setStatusFilter] = React.useState<(typeof filterOptions)[number]["value"]>("all");
+  const [selectedPharmacyId, setSelectedPharmacyId] = React.useState<string | null>(null);
+  const [activeTab, setActiveTab] = React.useState("overview");
+
+  const summaries = React.useMemo(() => {
+    const map = new Map<string, PharmacySummary>();
+    (pharmacies ?? []).forEach((pharmacy) => {
+      const relatedClaims = (claims ?? []).filter((claim) => matchesPharmacy(claim, pharmacy));
+      const summary: PharmacySummary = {
+        claims: relatedClaims,
+        outstanding: 0,
+        totalClaims: relatedClaims.length,
+        totalPaid: 0,
+        statementsDue: 0,
+        lastCheckDate: null,
+        topServices: {},
+      };
+
+      relatedClaims.forEach((claim) => {
+        summary.outstanding += claim.statementSent ? 0 : (claim.patientPay ?? 0);
+        summary.totalPaid += claim.paid ?? 0;
+        if (!claim.statementSent) {
+          summary.statementsDue += 1;
+        }
+        if (claim.checkDate) {
+          const iso = new Date(claim.checkDate).toISOString();
+          if (!summary.lastCheckDate || iso > summary.lastCheckDate) {
+            summary.lastCheckDate = iso;
+          }
+        }
+        if (claim.serviceDescription) {
+          const key = claim.serviceDescription;
+          summary.topServices[key] = (summary.topServices[key] ?? 0) + 1;
+        }
+      });
+      map.set(pharmacy.id, summary);
+    });
+    return map;
+  }, [pharmacies, claims]);
+
+  const filteredPharmacies = React.useMemo(() => {
+    const normalizedSearch = normalize(searchTerm);
+    return (pharmacies ?? []).filter((pharmacy) => {
+      const summary = summaries.get(pharmacy.id);
+
+      if (statusFilter === "active" && pharmacy.status !== "Active") {
+        return false;
+      }
+      if (statusFilter === "needs-review" && (!summary || summary.statementsDue === 0)) {
+        return false;
+      }
+      if (statusFilter === "prospect" && pharmacy.status !== "Prospect") {
+        return false;
+      }
+
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      const haystack = [
+        pharmacy.name,
+        pharmacy.contactName,
+        pharmacy.phone,
+        pharmacy.email,
+        pharmacy.address?.city,
+        pharmacy.address?.state,
+      ]
+        .filter(Boolean)
+        .map((value) => normalize(value?.toString()))
+        .join(" ");
+
+      return haystack.includes(normalizedSearch);
+    });
+  }, [pharmacies, summaries, statusFilter, searchTerm]);
+
+  React.useEffect(() => {
+    if (!selectedPharmacyId && filteredPharmacies.length) {
+      setSelectedPharmacyId(filteredPharmacies[0].id);
+    }
+  }, [filteredPharmacies, selectedPharmacyId]);
+
+  React.useEffect(() => {
+    if (selectedPharmacyId && !filteredPharmacies.some((item) => item.id === selectedPharmacyId)) {
+      setSelectedPharmacyId(filteredPharmacies[0]?.id ?? null);
+    }
+  }, [filteredPharmacies, selectedPharmacyId]);
+
+  const selectedPharmacy = React.useMemo(
+    () => filteredPharmacies.find((pharmacy) => pharmacy.id === selectedPharmacyId) ?? filteredPharmacies[0] ?? null,
+    [filteredPharmacies, selectedPharmacyId]
+  );
+
+  const selectedSummary = selectedPharmacy ? summaries.get(selectedPharmacy.id) ?? {
+    claims: [],
+    outstanding: 0,
+    totalClaims: 0,
+    totalPaid: 0,
+    statementsDue: 0,
+    lastCheckDate: null,
+    topServices: {},
+  } : null;
+
+  const dashboardTotals = React.useMemo(() => {
+    const base = { total: filteredPharmacies.length, outstanding: 0, due: 0, paid: 0 };
+    filteredPharmacies.forEach((pharmacy) => {
+      const summary = summaries.get(pharmacy.id);
+      if (!summary) return;
+      base.outstanding += summary.outstanding;
+      base.due += summary.statementsDue;
+      base.paid += summary.totalPaid;
+    });
+    return base;
+  }, [filteredPharmacies, summaries]);
+
+  const isLoading = pharmaciesLoading || claimsLoading;
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Pharmacy Partnerships"
+        description="Track pharmacy relationships, outstanding balances, and operational history to keep everything moving smoothly."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[340px,1fr]">
+        <div className="space-y-4">
+          <Card className="border-none bg-white/70 p-[1px] shadow-xl shadow-sky-200/50">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="space-y-3 border-b border-white/60">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-700">
+                  <Filter className="h-5 w-5 text-sky-500" /> Pharmacy Directory
+                </CardTitle>
+                <div className="flex flex-col gap-3">
+                  <Input
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Search by name, contact, or city"
+                    className="h-11 rounded-2xl border-none bg-white/80 px-4 text-sm shadow-inner"
+                  />
+                  <Tabs
+                    value={statusFilter}
+                    onValueChange={(value) => setStatusFilter(value as (typeof filterOptions)[number]["value"])}
+                  >
+                    <TabsList className="grid h-11 grid-cols-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                      {filterOptions.map((option) => (
+                        <TabsTrigger
+                          key={option.value}
+                          value={option.value}
+                          className="rounded-2xl px-2 text-xs font-semibold uppercase tracking-wide text-slate-500 transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-400 data-[state=active]:to-teal-400 data-[state=active]:text-white"
+                        >
+                          {option.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </CardHeader>
+              <CardContent className="px-0 py-0">
+                <ScrollArea className="h-[520px] px-4">
+                  <div className="space-y-3 py-4">
+                    {isLoading && (
+                      <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                        Loading pharmacies...
+                      </div>
+                    )}
+                    {!isLoading && filteredPharmacies.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                        No pharmacies match your filters yet.
+                      </div>
+                    )}
+                    {!isLoading &&
+                      filteredPharmacies.map((pharmacy) => {
+                        const summary = summaries.get(pharmacy.id);
+                        const isActive = selectedPharmacy && pharmacy.id === selectedPharmacy.id;
+
+                        return (
+                          <button
+                            key={pharmacy.id}
+                            onClick={() => {
+                              setSelectedPharmacyId(pharmacy.id);
+                              setActiveTab("overview");
+                            }}
+                            className={`w-full rounded-3xl border p-4 text-left transition hover:shadow-lg ${
+                              isActive
+                                ? "border-transparent bg-gradient-to-r from-sky-400/90 via-cyan-400/90 to-teal-400/90 text-white shadow-xl"
+                                : "border-white/60 bg-white/70 text-slate-600 hover:bg-white"
+                            }`}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className={`text-base font-semibold ${isActive ? "text-white" : "text-slate-700"}`}>
+                                  {pharmacy.name}
+                                </p>
+                                <p className={`text-xs ${isActive ? "text-white/80" : "text-slate-500"}`}>
+                                  {pharmacy.address?.city}, {pharmacy.address?.state}
+                                </p>
+                              </div>
+                              <div className="text-right">
+                                <p className={`text-sm font-semibold ${isActive ? "text-white" : "text-slate-700"}`}>
+                                  {formatCurrency(summary?.outstanding ?? 0)}
+                                </p>
+                                <p className={`text-[11px] uppercase tracking-wide ${isActive ? "text-white/80" : "text-slate-400"}`}>
+                                  Outstanding
+                                </p>
+                              </div>
+                            </div>
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                              {pharmacy.status && (
+                                <Badge variant={isActive ? "secondary" : "outline"}>{pharmacy.status}</Badge>
+                              )}
+                              {summary && summary.statementsDue > 0 && (
+                                <Badge variant="destructive">{summary.statementsDue} statements due</Badge>
+                              )}
+                              {summary && summary.totalClaims > 0 && (
+                                <Badge variant="outline" className={isActive ? "border-white/50 text-white" : "text-slate-500"}>
+                                  {summary.totalClaims} claims
+                                </Badge>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
+                  </div>
+                </ScrollArea>
+              </CardContent>
+            </div>
+          </Card>
+
+          <Card className="border-none bg-white/70 p-[1px] shadow-xl shadow-sky-200/50">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="border-b border-white/60 pb-4">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-700">
+                  <Layers className="h-5 w-5 text-teal-500" /> Network Pulse
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 p-6">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active Partners</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{dashboardTotals.total}</p>
+                    <p className="text-xs text-slate-500">Visible with current filters</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Outstanding</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{formatCurrency(dashboardTotals.outstanding)}</p>
+                    <p className="text-xs text-slate-500">Awaiting reimbursement</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Statements Due</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{dashboardTotals.due}</p>
+                    <p className="text-xs text-slate-500">Follow-up recommended</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/60 bg-white/80 p-4 shadow-inner">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Insurance Paid</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-700">{formatCurrency(dashboardTotals.paid)}</p>
+                    <p className="text-xs text-slate-500">Captured in cycle</p>
+                  </div>
+                </div>
+              </CardContent>
+            </div>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card className="border-none bg-white/70 p-[1px] shadow-2xl shadow-sky-200/60">
+            <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+              <CardHeader className="border-b border-white/60 pb-4">
+                <CardTitle className="flex items-center justify-between text-lg font-semibold text-slate-700">
+                  <span>Pharmacy Profile</span>
+                  {selectedPharmacy && (
+                    <Badge variant="outline" className="rounded-full border-sky-200 text-sky-600">
+                      {selectedPharmacy.status ?? "Status Pending"}
+                    </Badge>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6 p-6">
+                {!selectedPharmacy && (
+                  <div className="rounded-3xl border border-dashed border-slate-200/80 bg-white/70 p-6 text-center text-sm text-slate-500">
+                    Select a pharmacy to see detailed history and performance insights.
+                  </div>
+                )}
+
+                {selectedPharmacy && selectedSummary && (
+                  <div className="space-y-6">
+                    <div className="grid gap-6 lg:grid-cols-2">
+                      <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Contact</h3>
+                        <p className="mt-2 text-lg font-semibold text-slate-700">{selectedPharmacy.name}</p>
+                        {selectedPharmacy.address && (
+                          <p className="text-sm text-slate-500">
+                            {selectedPharmacy.address.street}
+                            <br />
+                            {selectedPharmacy.address.city}, {selectedPharmacy.address.state} {selectedPharmacy.address.zip}
+                          </p>
+                        )}
+                        <div className="mt-3 space-y-1 text-sm text-slate-500">
+                          {selectedPharmacy.contactName && <p>Contact: {selectedPharmacy.contactName}</p>}
+                          {selectedPharmacy.phone && <p>{selectedPharmacy.phone}</p>}
+                          {selectedPharmacy.email && <p>{selectedPharmacy.email}</p>}
+                          {selectedPharmacy.npi && <p>NPI: {selectedPharmacy.npi}</p>}
+                        </div>
+                      </div>
+                      <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Performance</h3>
+                        <div className="mt-4 grid gap-3 text-sm">
+                          <div className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/70 p-3">
+                            <span className="text-slate-500">Outstanding</span>
+                            <span className="font-semibold text-slate-700">{formatCurrency(selectedSummary.outstanding)}</span>
+                          </div>
+                          <div className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/70 p-3">
+                            <span className="text-slate-500">Insurance Paid</span>
+                            <span className="font-semibold text-slate-700">{formatCurrency(selectedSummary.totalPaid)}</span>
+                          </div>
+                          <div className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/70 p-3">
+                            <span className="text-slate-500">Statements Due</span>
+                            <span className="font-semibold text-slate-700">{selectedSummary.statementsDue}</span>
+                          </div>
+                          <div className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/70 p-3">
+                            <span className="text-slate-500">Last Payment</span>
+                            <span className="font-semibold text-slate-700">{formatDate(selectedSummary.lastCheckDate)}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Tabs value={activeTab} onValueChange={setActiveTab}>
+                      <TabsList className="mb-4 rounded-2xl bg-slate-100/60 p-[2px]">
+                        <TabsTrigger
+                          value="overview"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-400 data-[state=active]:to-cyan-400 data-[state=active]:text-white"
+                        >
+                          Overview
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="history"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-cyan-400 data-[state=active]:to-teal-400 data-[state=active]:text-white"
+                        >
+                          Claims
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="insights"
+                          className="rounded-2xl px-4 py-2 text-sm font-semibold text-slate-500 data-[state=active]:bg-gradient-to-r data-[state=active]:from-teal-400 data-[state=active]:to-emerald-300 data-[state=active]:text-white"
+                        >
+                          Insights
+                        </TabsTrigger>
+                      </TabsList>
+
+                      <TabsContent value="overview" className="space-y-4">
+                        <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                          <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                            <Building2 className="h-4 w-4 text-sky-500" /> Engagement Summary
+                          </h3>
+                          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Total Claims</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{selectedSummary.totalClaims}</p>
+                              <p className="text-xs text-slate-500">Filed with this pharmacy</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Top Service</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">
+                                {Object.entries(selectedSummary.topServices)
+                                  .sort((a, b) => b[1] - a[1])[0]?.[0] ?? "—"}
+                              </p>
+                              <p className="text-xs text-slate-500">Most common billing item</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Statements Due</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{selectedSummary.statementsDue}</p>
+                              <p className="text-xs text-slate-500">Pending patient follow-up</p>
+                            </div>
+                            <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                              <p className="text-xs uppercase tracking-wide text-slate-500">Outstanding</p>
+                              <p className="mt-1 text-2xl font-semibold text-slate-700">{formatCurrency(selectedSummary.outstanding)}</p>
+                              <p className="text-xs text-slate-500">Balance to recover</p>
+                            </div>
+                          </div>
+                        </div>
+                      </TabsContent>
+
+                      <TabsContent value="history" className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        {selectedSummary.claims.length === 0 ? (
+                          <p className="text-sm text-slate-500">No claims on record for this pharmacy yet.</p>
+                        ) : (
+                          <div className="overflow-x-auto">
+                            <Table>
+                              <TableHeader>
+                                <TableRow className="bg-white/70">
+                                  <TableHead>Check Date</TableHead>
+                                  <TableHead>Patient</TableHead>
+                                  <TableHead>Service</TableHead>
+                                  <TableHead className="text-right">Paid</TableHead>
+                                  <TableHead className="text-right">Outstanding</TableHead>
+                                  <TableHead>Status</TableHead>
+                                </TableRow>
+                              </TableHeader>
+                              <TableBody>
+                                {[...selectedSummary.claims]
+                                  .sort((a, b) => (b.checkDate ?? "").localeCompare(a.checkDate ?? ""))
+                                  .map((claim) => (
+                                    <TableRow key={claim.id} className="transition hover:bg-sky-50/70">
+                                      <TableCell>{formatDate(claim.checkDate)}</TableCell>
+                                      <TableCell>
+                                        <p className="font-medium text-slate-700">{claim.patientName}</p>
+                                        <p className="text-xs text-slate-500">{claim.rx}</p>
+                                      </TableCell>
+                                      <TableCell>
+                                        <p className="text-sm text-slate-600">{claim.serviceDescription}</p>
+                                        <p className="text-xs text-slate-400">{claim.productId}</p>
+                                      </TableCell>
+                                      <TableCell className="text-right">{formatCurrency(claim.paid)}</TableCell>
+                                      <TableCell className="text-right">{formatCurrency(claim.patientPay)}</TableCell>
+                                      <TableCell>
+                                        <Badge variant={claim.statementSent ? "outline" : "destructive"}>
+                                          {claim.statementSent ? "Statement Sent" : "Needs Statement"}
+                                        </Badge>
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                              </TableBody>
+                            </Table>
+                          </div>
+                        )}
+                      </TabsContent>
+
+                      <TabsContent value="insights" className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-inner">
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                            <h4 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                              <Target className="h-4 w-4 text-sky-500" /> Action Items
+                            </h4>
+                            <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                              <li>
+                                • {selectedSummary.statementsDue > 0 ? `${selectedSummary.statementsDue} patient statements` : "No statements"} pending.
+                              </li>
+                              <li>
+                                • {selectedSummary.outstanding > 0 ? `${formatCurrency(selectedSummary.outstanding)} outstanding balance` : "No outstanding balance"}.
+                              </li>
+                              <li>
+                                • Last payment {formatDate(selectedSummary.lastCheckDate)}.
+                              </li>
+                            </ul>
+                          </div>
+                          <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
+                            <h4 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                              <TrendingUp className="h-4 w-4 text-teal-500" /> Service Mix
+                            </h4>
+                            <div className="mt-3 space-y-2 text-sm text-slate-600">
+                              {Object.entries(selectedSummary.topServices)
+                                .sort((a, b) => b[1] - a[1])
+                                .slice(0, 5)
+                                .map(([service, count]) => (
+                                  <div key={service} className="flex items-center justify-between">
+                                    <span>{service}</span>
+                                    <span className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-500">{count}</span>
+                                  </div>
+                                ))}
+                              {Object.keys(selectedSummary.topServices).length === 0 && (
+                                <p className="text-sm text-slate-500">No service mix data yet.</p>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </TabsContent>
+                    </Tabs>
+                  </div>
+                )}
+              </CardContent>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/storage/page.tsx
+++ b/src/app/(app)/storage/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import * as React from "react";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { initializeFirebase } from "@/firebase";
+import { useToast } from "@/hooks/use-toast";
+import { getDownloadURL, getMetadata, getStorage, listAll, ref, type StorageReference } from "firebase/storage";
+import { ArrowDownToLine, Cloud, Copy, RefreshCcw } from "lucide-react";
+
+interface StorageFile {
+  name: string;
+  fullPath: string;
+  size: number;
+  updated?: string;
+  contentType?: string;
+  url?: string;
+}
+
+async function collectFiles(reference: StorageReference, prefix = ""): Promise<StorageFile[]> {
+  const result = await listAll(reference);
+  const files: StorageFile[] = [];
+
+  for (const item of result.items) {
+    const metadata = await getMetadata(item).catch(() => undefined);
+    const downloadUrl = await getDownloadURL(item).catch(() => undefined);
+
+    files.push({
+      name: item.name,
+      fullPath: prefix ? `${prefix}/${item.name}` : item.name,
+      size: metadata?.size ?? 0,
+      updated: metadata?.updated,
+      contentType: metadata?.contentType ?? undefined,
+      url: downloadUrl,
+    });
+  }
+
+  for (const folder of result.prefixes) {
+    const nested = await collectFiles(folder, prefix ? `${prefix}/${folder.name}` : folder.name);
+    files.push(...nested);
+  }
+
+  return files;
+}
+
+function formatSize(bytes: number) {
+  if (!bytes) return "—";
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(size < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function formatDate(value?: string) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function StoragePage() {
+  const { toast } = useToast();
+  const firebase = initializeFirebase();
+  const storage = React.useMemo(() => {
+    try {
+      return firebase.firebaseApp ? getStorage(firebase.firebaseApp) : null;
+    } catch (error) {
+      console.warn("Unable to initialize storage", error);
+      return null;
+    }
+  }, [firebase.firebaseApp]);
+
+  const [files, setFiles] = React.useState<StorageFile[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = React.useState("");
+
+  const loadFiles = React.useCallback(async () => {
+    if (!storage) {
+      setError("Firebase Storage is not available right now.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const rootRef = ref(storage);
+      const collected = await collectFiles(rootRef);
+      collected.sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""));
+      setFiles(collected);
+    } catch (err) {
+      console.error("Failed to load storage files", err);
+      setError("We couldn't load files from storage. Try refreshing.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [storage]);
+
+  React.useEffect(() => {
+    loadFiles();
+  }, [loadFiles]);
+
+  const filteredFiles = React.useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+    if (!normalized) return files;
+    return files.filter((file) => file.fullPath.toLowerCase().includes(normalized));
+  }, [files, searchTerm]);
+
+  const handleCopyLink = (file: StorageFile) => {
+    if (!file.url) {
+      toast({
+        title: "Link unavailable",
+        description: "We couldn't fetch a download link yet.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      toast({
+        title: "Clipboard unsupported",
+        description: "Your browser can't copy automatically. Use the download button instead.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(file.url)
+      .then(() => {
+        toast({
+          title: "Link copied",
+          description: "Share this file link with your team.",
+        });
+      })
+      .catch(() => {
+        toast({
+          title: "Unable to copy",
+          description: "Copy the link manually from the download button.",
+          variant: "destructive",
+        });
+      });
+  };
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="File Library"
+        description="Browse every file you've uploaded. Download receipts, statements, and exports in seconds."
+        children={
+          <Button
+            onClick={loadFiles}
+            className="rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-teal-400 px-5 text-white shadow-lg hover:shadow-xl"
+          >
+            <RefreshCcw className="mr-2 h-4 w-4" /> Refresh
+          </Button>
+        }
+      />
+
+      <Card className="border-none bg-white/70 p-[1px] shadow-2xl shadow-sky-200/60">
+        <div className="rounded-3xl bg-gradient-to-br from-white/90 via-white/80 to-white/60">
+          <CardHeader className="space-y-3 border-b border-white/60">
+            <CardTitle className="flex items-center justify-between text-lg font-semibold text-slate-700">
+              <span className="flex items-center gap-2">
+                <Cloud className="h-5 w-5 text-sky-500" /> Storage files
+              </span>
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search files"
+                className="h-11 w-full max-w-xs rounded-2xl border-none bg-white/80 px-4 text-sm shadow-inner"
+              />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-0 py-0">
+            {error && (
+              <div className="mx-6 mt-4 rounded-3xl border border-dashed border-red-200 bg-red-50/80 p-4 text-sm text-red-600">
+                {error}
+              </div>
+            )}
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-white/70">
+                    <TableHead>File</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="text-right">Size</TableHead>
+                    <TableHead>Updated</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoading ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="h-24 text-center text-sm text-slate-500">
+                        Loading files...
+                      </TableCell>
+                    </TableRow>
+                  ) : filteredFiles.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="h-24 text-center text-sm text-slate-500">
+                        No files found.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    filteredFiles.map((file) => (
+                      <TableRow key={file.fullPath} className="transition hover:bg-sky-50/70">
+                        <TableCell>
+                          <div className="flex flex-col">
+                            <span className="font-medium text-slate-700">{file.name}</span>
+                            <span className="text-xs text-slate-500">{file.fullPath}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="rounded-full border-slate-200 text-slate-500">
+                            {file.contentType ?? "Unknown"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right text-sm text-slate-600">{formatSize(file.size)}</TableCell>
+                        <TableCell className="text-sm text-slate-600">{formatDate(file.updated)}</TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="rounded-full border border-slate-200 bg-white/80 px-3 text-slate-600 hover:bg-white"
+                              onClick={() => handleCopyLink(file)}
+                            >
+                              <Copy className="mr-2 h-4 w-4" /> Copy link
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="rounded-full border border-slate-200 bg-white/80 px-3 text-slate-600 hover:bg-white"
+                              asChild
+                              disabled={!file.url}
+                            >
+                              <a href={file.url ?? "#"} target="_blank" rel="noopener noreferrer">
+                                <ArrowDownToLine className="mr-2 h-4 w-4" /> Download
+                              </a>
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,58 +4,57 @@
 
 @layer base {
   :root {
-    --background: 208 100% 97%; /* #F0F8FF */
-    --foreground: 224 71% 4%; /* A dark blue for contrast */
+    --background: 198 100% 96%;
+    --foreground: 225 71% 6%;
 
     --card: 0 0% 100%;
-    --card-foreground: 224 71% 4%;
+    --card-foreground: 222 47% 11%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 224 71% 4%;
+    --popover-foreground: 222 47% 11%;
 
-    --primary: 196 53% 64%; /* #72BCD4 */
+    --primary: 222 89% 66%;
     --primary-foreground: 210 40% 98%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 200 90% 88%;
+    --secondary-foreground: 221 39% 20%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 199 100% 92%;
+    --muted-foreground: 214 32% 35%;
 
-    --accent: 174 43% 85%; /* #B2DFDB */
-    --accent-foreground: 175 35% 25%;
+    --accent: 188 76% 76%;
+    --accent-foreground: 206 74% 18%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 196 53% 54%; /* Darker shade of primary */
+    --border: 200 54% 89%;
+    --input: 200 54% 89%;
+    --ring: 198 100% 60%;
 
-    --radius: 0.5rem;
+    --radius: 0.85rem;
   }
 
   .dark {
-    /* Keeping dark mode defaults but they won't be used unless a toggle is added */
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 196 53% 64%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 174 43% 75%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 196 53% 74%;
+    --background: 225 25% 8%;
+    --foreground: 0 0% 100%;
+    --card: 222 30% 18%;
+    --card-foreground: 0 0% 100%;
+    --popover: 222 30% 18%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 222 89% 66%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 199 60% 30%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 199 60% 30%;
+    --muted-foreground: 199 100% 80%;
+    --accent: 188 76% 66%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 0 72% 40%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 210 45% 26%;
+    --input: 210 45% 26%;
+    --ring: 198 100% 60%;
   }
 }
 
@@ -64,7 +63,22 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply min-h-screen bg-background text-foreground;
+    background-image: radial-gradient(circle at top left, hsla(217, 91%, 60%, 0.35), transparent 45%),
+      radial-gradient(circle at bottom right, hsla(184, 76%, 65%, 0.35), transparent 40%),
+      linear-gradient(135deg, hsla(226, 95%, 78%, 0.4), hsla(199, 100%, 82%, 0.6));
+    background-attachment: fixed;
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  }
+}
+
+@layer utilities {
+  .glass-panel {
+    @apply rounded-3xl border border-white/40 bg-white/30 shadow-xl backdrop-blur-xl;
+  }
+
+  .glow-ring {
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4), 0 20px 45px rgba(56, 189, 248, 0.35);
   }
 }
 

--- a/src/components/claims-summary.tsx
+++ b/src/components/claims-summary.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileWarning, CheckCircle, DollarSign } from "lucide-react";
 import { useMemo } from "react";
 import type { Claim } from "@/lib/types";
+import { formatCurrency } from "@/lib/utils";
 
 export function ClaimsSummary({ initialClaims = [] }: { initialClaims?: Claim[] }) {
     const { claims } = useClaims(initialClaims);
@@ -13,47 +14,88 @@ export function ClaimsSummary({ initialClaims = [] }: { initialClaims?: Claim[] 
       const safeClaims = claims || [];
       const statementsNeeded = safeClaims.filter(c => !c.statementSent).length;
       const statementsSent = safeClaims.length - statementsNeeded;
-      const totalOutstanding = safeClaims.filter(c => !c.statementSent).reduce((acc, c) => acc + c.amount, 0);
-      return { statementsNeeded, statementsSent, totalOutstanding, totalClaims: safeClaims.length };
+      const totalOutstanding = safeClaims
+        .filter(c => !c.statementSent)
+        .reduce((acc, c) => acc + (c.patientPay ?? 0), 0);
+      const totalRevenue = safeClaims.reduce((acc, c) => acc + (c.paid ?? 0), 0);
+      return { statementsNeeded, statementsSent, totalOutstanding, totalClaims: safeClaims.length, totalRevenue };
   }, [claims]);
 
     return (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Outstanding Balance</CardTitle>
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">${summary.totalOutstanding.toFixed(2)}</div>
-            <p className="text-xs text-muted-foreground">
-              Total from claims needing statements
-            </p>
-          </CardContent>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card className="relative overflow-hidden border-none bg-white/70 p-[1px] shadow-lg shadow-sky-200/50 backdrop-blur-xl transition hover:scale-[1.01]">
+          <div className="rounded-2xl bg-gradient-to-br from-white/80 via-white/70 to-white/50 p-6">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 px-0 pb-2 pt-0">
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                Outstanding Balance
+              </CardTitle>
+              <span className="rounded-full bg-gradient-to-br from-sky-500/20 to-indigo-500/30 p-2 text-sky-600">
+                <DollarSign className="h-4 w-4" />
+              </span>
+            </CardHeader>
+            <CardContent className="px-0">
+              <div className="text-3xl font-bold text-slate-800">
+                {formatCurrency(summary.totalOutstanding)}
+              </div>
+              <p className="mt-2 text-xs font-medium text-slate-500">
+                Total owed across unsent statements
+              </p>
+            </CardContent>
+          </div>
         </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Statements Needed</CardTitle>
-            <FileWarning className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{summary.statementsNeeded}</div>
-            <p className="text-xs text-muted-foreground">
-              New claims requiring a statement
-            </p>
-          </CardContent>
+        <Card className="relative overflow-hidden border-none bg-white/70 p-[1px] shadow-lg shadow-sky-200/50 backdrop-blur-xl transition hover:scale-[1.01]">
+          <div className="rounded-2xl bg-gradient-to-br from-white/80 via-white/70 to-white/50 p-6">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 px-0 pb-2 pt-0">
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                Statements Needed
+              </CardTitle>
+              <span className="rounded-full bg-gradient-to-br from-indigo-500/20 to-sky-500/30 p-2 text-indigo-600">
+                <FileWarning className="h-4 w-4" />
+              </span>
+            </CardHeader>
+            <CardContent className="px-0">
+              <div className="text-3xl font-bold text-slate-800">{summary.statementsNeeded}</div>
+              <p className="mt-2 text-xs font-medium text-slate-500">
+                Awaiting statement delivery
+              </p>
+            </CardContent>
+          </div>
         </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Statements Sent</CardTitle>
-            <CheckCircle className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{summary.statementsSent}</div>
-            <p className="text-xs text-muted-foreground">
-              Out of {summary.totalClaims} total claims
-            </p>
-          </CardContent>
+        <Card className="relative overflow-hidden border-none bg-white/70 p-[1px] shadow-lg shadow-sky-200/50 backdrop-blur-xl transition hover:scale-[1.01]">
+          <div className="rounded-2xl bg-gradient-to-br from-white/80 via-white/70 to-white/50 p-6">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 px-0 pb-2 pt-0">
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                Statements Sent
+              </CardTitle>
+              <span className="rounded-full bg-gradient-to-br from-teal-400/20 to-cyan-400/30 p-2 text-teal-600">
+                <CheckCircle className="h-4 w-4" />
+              </span>
+            </CardHeader>
+            <CardContent className="px-0">
+              <div className="text-3xl font-bold text-slate-800">{summary.statementsSent}</div>
+              <p className="mt-2 text-xs font-medium text-slate-500">
+                Out of {summary.totalClaims} total claims
+              </p>
+            </CardContent>
+          </div>
+        </Card>
+        <Card className="relative overflow-hidden border-none bg-white/70 p-[1px] shadow-lg shadow-sky-200/50 backdrop-blur-xl transition hover:scale-[1.01]">
+          <div className="rounded-2xl bg-gradient-to-br from-white/80 via-white/70 to-white/50 p-6">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 px-0 pb-2 pt-0">
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                Insurance Paid
+              </CardTitle>
+              <span className="rounded-full bg-gradient-to-br from-sky-500/20 to-teal-400/30 p-2 text-sky-600">
+                <DollarSign className="h-4 w-4" />
+              </span>
+            </CardHeader>
+            <CardContent className="px-0">
+              <div className="text-3xl font-bold text-slate-800">
+                {formatCurrency(summary.totalRevenue)}
+              </div>
+              <p className="mt-2 text-xs font-medium text-slate-500">Captured this billing cycle</p>
+            </CardContent>
+          </div>
         </Card>
       </div>
     );

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -8,14 +8,18 @@ type PageHeaderProps = {
 
 export function PageHeader({ title, description, children }: PageHeaderProps) {
   return (
-    <div className="flex items-center justify-between">
-      <div className="grid gap-1">
-        <h1 className="text-2xl font-bold tracking-tight md:text-3xl">{title}</h1>
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="space-y-2">
+        <h1 className="bg-gradient-to-r from-indigo-500 via-sky-500 to-teal-400 bg-clip-text text-3xl font-bold tracking-tight text-transparent md:text-4xl">
+          {title}
+        </h1>
         {description && (
-          <p className="text-muted-foreground">{description}</p>
+          <p className="max-w-2xl text-sm font-medium text-slate-600 md:text-base">
+            {description}
+          </p>
         )}
       </div>
-      {children && <div className="flex items-center gap-2">{children}</div>}
+      {children && <div className="flex flex-wrap items-center gap-3">{children}</div>}
     </div>
   );
 }

--- a/src/hooks/use-notes.ts
+++ b/src/hooks/use-notes.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import type { JennNote } from "@/lib/types";
+import { useCollection, useFirestore, useMemoFirebase } from "@/firebase";
+import { collection, deleteDoc, doc, setDoc, updateDoc } from "firebase/firestore";
+
+export type CreateNoteInput = {
+  title: string;
+  body: string;
+  tags?: string[];
+  mood?: JennNote["mood"];
+};
+
+export function useJennNotes(initialNotes: JennNote[] = []) {
+  const firestore = useFirestore();
+
+  const notesCollection = useMemoFirebase(() => {
+    if (!firestore) return null;
+    return collection(firestore, "notes");
+  }, [firestore]);
+
+  const { data, isLoading, error } = useCollection<JennNote>(notesCollection);
+
+  const notes = React.useMemo(() => {
+    const values = data ?? initialNotes ?? [];
+    return [...values].sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+  }, [data, initialNotes]);
+
+  const addNote = React.useCallback(
+    async (input: CreateNoteInput) => {
+      if (!firestore) return null;
+      const ref = doc(collection(firestore, "notes"));
+      const now = new Date().toISOString();
+      await setDoc(ref, {
+        title: input.title,
+        body: input.body,
+        tags: input.tags ?? [],
+        mood: input.mood ?? "follow-up",
+        createdAt: now,
+        updatedAt: now,
+      });
+      return ref.id;
+    },
+    [firestore]
+  );
+
+  const updateNote = React.useCallback(
+    async (noteId: string, updates: Partial<CreateNoteInput>) => {
+      if (!firestore) return;
+      const ref = doc(firestore, "notes", noteId);
+      await updateDoc(ref, {
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      });
+    },
+    [firestore]
+  );
+
+  const removeNote = React.useCallback(
+    async (noteId: string) => {
+      if (!firestore) return;
+      const ref = doc(firestore, "notes", noteId);
+      await deleteDoc(ref);
+    },
+    [firestore]
+  );
+
+  return {
+    notes,
+    isLoading,
+    error,
+    addNote,
+    updateNote,
+    removeNote,
+  };
+}

--- a/src/hooks/use-patients.ts
+++ b/src/hooks/use-patients.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import * as React from "react";
+import type { Patient } from "@/lib/types";
+import { useCollection, useFirestore, useMemoFirebase } from "@/firebase";
+import { collection, doc } from "firebase/firestore";
+import { updateDocumentNonBlocking } from "@/firebase/non-blocking-updates";
+
+export function usePatients(initialPatients: Patient[] = []) {
+  const firestore = useFirestore();
+
+  const patientsCollection = useMemoFirebase(() => {
+    if (!firestore) return null;
+    return collection(firestore, "patients");
+  }, [firestore]);
+
+  const { data, isLoading, error } = useCollection<Patient>(patientsCollection);
+
+  const patients = React.useMemo(() => {
+    const values = data ?? initialPatients ?? [];
+    return [...values].sort((a, b) => {
+      const nameA = `${a.lastName ?? ""} ${a.firstName ?? ""}`.trim().toLowerCase();
+      const nameB = `${b.lastName ?? ""} ${b.firstName ?? ""}`.trim().toLowerCase();
+      return nameA.localeCompare(nameB);
+    });
+  }, [data, initialPatients]);
+
+  const updatePatient = React.useCallback(
+    (patientId: string, updates: Partial<Patient>) => {
+      if (!firestore) return;
+      const ref = doc(firestore, "patients", patientId);
+      updateDocumentNonBlocking(ref, updates);
+    },
+    [firestore]
+  );
+
+  return {
+    patients,
+    isLoading,
+    error,
+    updatePatient,
+  };
+}

--- a/src/hooks/use-pharmacies.ts
+++ b/src/hooks/use-pharmacies.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import type { Pharmacy } from "@/lib/types";
+import { useCollection, useFirestore, useMemoFirebase } from "@/firebase";
+import { collection, doc } from "firebase/firestore";
+import { updateDocumentNonBlocking } from "@/firebase/non-blocking-updates";
+
+export function usePharmacies(initialPharmacies: Pharmacy[] = []) {
+  const firestore = useFirestore();
+
+  const pharmaciesCollection = useMemoFirebase(() => {
+    if (!firestore) return null;
+    return collection(firestore, "pharmacies");
+  }, [firestore]);
+
+  const { data, isLoading, error } = useCollection<Pharmacy>(pharmaciesCollection);
+
+  const pharmacies = React.useMemo(() => {
+    const values = data ?? initialPharmacies ?? [];
+    return [...values].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+  }, [data, initialPharmacies]);
+
+  const updatePharmacy = React.useCallback(
+    (pharmacyId: string, updates: Partial<Pharmacy>) => {
+      if (!firestore) return;
+      const ref = doc(firestore, "pharmacies", pharmacyId);
+      updateDocumentNonBlocking(ref, updates);
+    },
+    [firestore]
+  );
+
+  return {
+    pharmacies,
+    isLoading,
+    error,
+    updatePharmacy,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,10 @@ export interface Patient {
     state: string;
     zip: string;
   };
+  phone?: string;
+  email?: string;
+  status?: "Active" | "Inactive" | "Collections";
+  lastVisitAt?: string | null;
 }
 
 export interface Claim {
@@ -37,4 +41,33 @@ export interface Claim {
   statementSent2nd: boolean; // 2nd Statement Sent?
   statementSentAt?: string | null;
   statementSent2ndAt?: string | null;
+}
+
+export interface Pharmacy {
+  id: string;
+  name: string;
+  npi?: string;
+  contactName?: string;
+  phone?: string;
+  email?: string;
+  status?: "Active" | "Paused" | "Prospect";
+  services?: string[];
+  address?: {
+    street?: string;
+    city?: string;
+    state?: string;
+    zip?: string;
+  };
+  notes?: string;
+  lastSyncAt?: string | null;
+}
+
+export interface JennNote {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  tags?: string[];
+  mood?: "celebrate" | "todo" | "follow-up" | "idea";
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,15 +1,77 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-import type { Patient } from "./types"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import type { Patient } from "./types";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 export function calculateAccountNumber(patient: Patient): string {
-  const [year, month, day] = patient.dateOfBirth.split('-');
+  const [year, month, day] = patient.dateOfBirth.split("-");
   const firstInitial = patient.firstName.charAt(0).toUpperCase();
   const lastInitial = patient.lastName.charAt(0).toUpperCase();
 
   return `${firstInitial}${month}0${day}${lastInitial}${year}`;
+}
+
+export function parseCurrency(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value !== "string") {
+    return 0;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  const isNegative = /\((.*)\)/.test(trimmed) || trimmed.startsWith("-");
+  const numeric = trimmed
+    .replace(/[,$\s]/g, "")
+    .replace(/^[^0-9.-]+/, "")
+    .replace(/[^0-9.\-]/g, "");
+
+  if (!numeric) {
+    return 0;
+  }
+
+  const parsed = parseFloat(numeric);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+
+  return isNegative ? -Math.abs(parsed) : parsed;
+}
+
+export function formatCurrency(value: number | null | undefined, { fallback = "$0.00" } = {}): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function parseBooleanFlag(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value === 1;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["true", "yes", "y", "sent", "1"].includes(normalized);
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Summary
- harden CSV imports with currency parsing utilities and safer statement fallbacks
- add searchable patient and pharmacy management dashboards backed by new hooks
- create Jenn's notes workspace and storage file browser with refreshed gradients and layout polish

## Testing
- npm run typecheck --silent

------
https://chatgpt.com/codex/tasks/task_b_68d439fc5a18832e88c887e26d83e0ee